### PR TITLE
feat: show logged hours for users on tasks

### DIFF
--- a/src/install.user.js
+++ b/src/install.user.js
@@ -7,7 +7,7 @@
 // @website       https://github.com/spreadmonitor-playground/github-logged-time
 // @iconURL       https://spreadmonitor.com/assets/logo.svg
 
-// @version       0.5
+// @version       0.6
 // @downloadURL   https://cdn.jsdelivr.net/gh/spreadmonitor-playground/github-logged-time/src/install.user.js
 
 // @noframes
@@ -25,7 +25,7 @@
 
 // ==/UserScript==
 
-(function() {
+(function () {
   'use strict';
   /**
    * Your personal Toggl API key from https://toggl.com/app/profile.
@@ -44,5 +44,12 @@
    */
   const projectIdMap = {};
 
-  new GithubLoggedTimeChart({ togglApiKey, projectIdMap });
+  /**
+   * A mapper object for pairing Github usernames to Toggle usernames.
+   *
+   * @type {{ [key: string] : string }}
+   */
+  const usernameMap = {};
+
+  new GithubLoggedTimeChart({ togglApiKey, projectIdMap, usernameMap });
 })();


### PR DESCRIPTION
# Description

This PR adds a feature which enables listing out the users who worked on a specific task determined by task number from Toggl and how many hours they worked individually and then renders them on the screen under the chart.