### PR TITLE
docs: fix docs for username map

### DIFF
--- a/src/install.user.js
+++ b/src/install.user.js
@@ -45,7 +45,7 @@
   const projectIdMap = {};
 
   /**
-   * A mapper object for pairing Github usernames to Toggle usernames.
+   * A mapper object for pairing Toggle usernames to Github usernames.
    *
    * @type {{ [key: string] : string }}
    */


### PR DESCRIPTION
### Description
This PR changes the docs for `usernameMap` configuration value because it was misleading.